### PR TITLE
nameserver in /etc/resolv.conf on nodes

### DIFF
--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -19,7 +19,7 @@
 #
 
 env_filter = " AND dns_config_environment:#{node[:dns][:config][:environment]}"
-nodes = search(:node, "roles:dns-server#{env_filter}")
+nodes = search(:node, "roles:dns-server")
 
 dns_list = []
 if !nodes.nil? and !nodes.empty?


### PR DESCRIPTION
when using the Dell Hadoop RA, /etc/resolv.conf isn't configured with a nameserver parameter causing DNS resolution to fail on the nodes.  this commit fixes the issue preventing the creation of the nameserver parameter.

i can't say that i understand why it fixes it exactly, but this works in my environment.
