### PR TITLE
DE656 - DNS not starting on the first pass [1/4]

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -65,15 +65,6 @@ service "bind9" do
   action :enable
 end
 
-file "/etc/bind/named.conf.local" do
-  owner "root"
-  group "root"
-  mode 0644
-  content ""
-  action :create
-  not_if do File.exists?("/etc/bind/named.conf.local") end
-end
-
 file "/etc/bind/hosts" do
   owner "root"
   group "root"
@@ -109,6 +100,10 @@ bash "build-domain-file" do
     echo 'include "/etc/bind/named.conf.options";' >> named.conf.new
     mv named.conf.new named.conf.local
     cp * /etc/bind
+
+    touch -r /etc/motd /etc/bind/hosts
+    touch -r /etc/motd /etc/bind/netargs
+    touch -r /etc/motd /etc/bind/named.conf.local
 
     rm -rf /tmp/tmp.$$
 EOH


### PR DESCRIPTION
Timing issue with file create times not having enough skew on the first pass.

 chef/cookbooks/bind9/recipes/default.rb |    4 ++++
 1 files changed, 4 insertions(+), 0 deletions(-)
