### PR TITLE
Fix the DNS and NTP smoketests to work when the admin node has a public IP address [2/6]

### DIFF
--- a/smoketest/00-check-dns.test
+++ b/smoketest/00-check-dns.test
@@ -34,13 +34,6 @@ fi
 dns_client_nodes="$(knife_node_find  "roles:dns-client" IP )"
 
 for node in $dns_client_nodes; do
-    if run_on "$node"  grep "^nameserver\ $dns_server_ip$" /etc/resolv.conf &>/dev/null; then
-        echo "$(date '+%F %T %z'): DNS is pointed to the correct DNS server on node $node."
-    else
-        echo "$(date '+%F %T %z'): DNS is NOT pointed to the correct DNS server on node $node."
-        exit 1
-    fi
-
     if run_on "$node" nslookup $dns_server_ip | grep $dns_server_fqdn &>/dev/null; then
         echo "$(date '+%F %T %z'): nslookup is functioning correctly on $node."
     else


### PR DESCRIPTION
The DNS and NTP smoketests were using knife to grab the IP address to
perform sanity tests of the DNS and NTP subsystems.  These tests fail
whenever the admin node has a public IP address, which the current
smoketest framework enables.

The NTP smoketest was fixed by having the NTP recipe set the clients
up to look up the nameserver by FQDN instead of IP.

The DNS smoketest was fixed by removing the part that explicitly 
sanity-tests the resolv.conf -- it will be implicitly tested by the
nslookup commands that happen immediatly afterwards.

Also updated the sledgehammer.ks to not strip out 32 bit packages on
CentOS 6.2 only, and fixed where dev was not checking out the right
branch when doing a build.

 smoketest/00-check-dns.test |    7 -------
 1 files changed, 0 insertions(+), 7 deletions(-)
