### PR TITLE
Attempt to make ganglia more resilient for DNS issues and fix allocate mode escape [1/7]

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -138,7 +138,8 @@ cluster_zone[:hosts] ||= Mash.new
 cluster_zone[:nameservers] ||= ["#{node[:fqdn]}."]
 populate_soa_defaults(cluster_zone)
 # Get the config environment filter
-env_filter = "dns_config_environment:#{node[:dns][:config][:environment]}"
+#env_filter = "dns_config_environment:#{node[:dns][:config][:environment]}"
+env_filter = "*:*" # Get all nodes for now.  This is a hack around a timing issue in ganglia.
 # Get the list of nodes
 nodes = search(:node, "#{env_filter}")
 nodes.each do |n|


### PR DESCRIPTION
 chef/cookbooks/bind9/recipes/default.rb |    3 ++-
 1 files changed, 2 insertions(+), 1 deletions(-)
