### PR TITLE
re-factor out intialize method in controllers [2/22]

### DIFF
--- a/crowbar_framework/app/controllers/dns_controller.rb
+++ b/crowbar_framework/app/controllers/dns_controller.rb
@@ -14,8 +14,12 @@
 # 
 
 class DnsController < BarclampController
-  def initialize
-    @service_object = DnsService.new logger
+  before_filter :set_service_object
+ 
+  def set_service_object
+      @service_object = DnsService.new logger
   end
+
+  private :set_service_object
 end
 


### PR DESCRIPTION
Fixed problem with layout rendering due to initialize method not calling super.  Refactored to use before_filter method to load @service_object and deleted initialize method.

 .../app/controllers/dns_controller.rb              |   46 +++++++++++---------
 1 files changed, 25 insertions(+), 21 deletions(-)
