### PR TITLE
First pass at getting native package based installs working on Uubntu and Redhat. [3/6]

### DIFF
--- a/crowbar_framework/app/controllers/dns_controller.rb
+++ b/crowbar_framework/app/controllers/dns_controller.rb
@@ -14,5 +14,19 @@
 # 
 
 class DnsController < BarclampController
+
+  # Override proposal_create to inject default domain and support
+  # attributes if we are creating one with a default proposal.
+
+  def proposal_create
+    dns = (params[:attributes][:dns] || Hash.new)
+    if dns[:domain].nil? || (dns[:domain] == "pod.your.cloud.org")
+      dns[:domain]=%x{hostname -d}.strip
+      dns[:contact]="support@#{dns[:domain]}"
+      params[:attributes] ||= Hash.new
+      params[:attributes][:dns]=dns
+    end
+    super
+  end
 end
 


### PR DESCRIPTION
This is a nonfunctional attempt at getting and admin node installed
using OS native packages for Ubuntu and Debian.  The codepaths for the
traditional Dell build and admin node codepaths have the following
changes:

1: Crowbar package cache generation for the admin node was moved to
the post-install phase of the relavent OS deploys for the admin node.
This was done so that the post-install script will have the tools
necessary to generate repository metadata for the native barclamp
packages.

2: The crowbar framework no longer requires a declaration for
the machine-install user in the default proposal for the Crowbar
barclamp.  Instead, it will create the machine-install user with a
random password when the crowbar barclamp is set up. The login
information for the machine-install user will continue to be stored in
/etc/crowbar.install.key.

3: The DNS barclamp will detect when you are deploying with an
unmodified default proposal and attempt to rewrite the domain
information to match the current state of the admin node.

4: The provisioner no longer needs to be told what the default OS is.
It will infer it based on the OS the admin node is using if not told
via proposal.

These changes help by allowing us to deploy an admin node without
having to hack up proposal templates with sed as part of the install
process.

 .../app/controllers/dns_controller.rb              |   14 ++++++++++++++
 1 file changed, 14 insertions(+)

Crowbar-Pull-ID: 5a61c0feb8bea25dbf1b92b356a5c55f23cd28ba

Crowbar-Release: development
