### PR TITLE
restructure to test deployment creation and access through barclamp id [2/2]

### DIFF
--- a/crowbar_engine/barclamp_dns/app/controllers/barclamp_dns/barclamps_controller.rb
+++ b/crowbar_engine/barclamp_dns/app/controllers/barclamp_dns/barclamps_controller.rb
@@ -13,7 +13,7 @@
 # limitations under the License. 
 # 
 
-class BarclampDns::BarclampsController < BarclampController
+class BarclampDns::BarclampsController < BarclampsController
 
   # Override proposal_create to inject default domain and support
   # attributes if we are creating one with a default proposal.


### PR DESCRIPTION
Restructure BDD "deployment" feature scenarios to account for the fact that default deployments are now created for core barclamps, and one cannot create another deployment for most of these in the tests. New tests verify that a singlelton barclamp can only have one deployment, and that a multiple deployment barclamp can have several, and that accessing them can be filtered by barclamp id.

 .../barclamp_dns/barclamps_controller.rb           |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 2b6db4426440080ec16eaad248da76d8ba954e24

Crowbar-Release: development
