### PR TITLE
Bootstrapping the Admin Node, Part n of m [3/5]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -27,6 +27,20 @@ barclamp:
   member:
     - crowbar
 
+roles:
+  - name: dns-server
+    jig: chef
+    flags:
+      - bootstrap
+    requires:
+      - network
+  - name: dns-client
+    jig: chef
+    flags:
+      - discovery
+    requires:
+      - dns-server
+
 crowbar:
   layout: 2.0
   order: 30


### PR DESCRIPTION
This pull request series allows Crowbar to get further along with
bootstrapping the admin node.
- The chef barclamp has been refactored to build run lists that
  include all the node-local prerequisites for any given node.  More
  thought is needed here -- we will probably wind up having to
  maintain a real fully-fleshed out run list per node.
- Attrib handling per node role has been made a little more
  fine-grained.  Specifically, we now have two outbound data
  locations, one for user-defined data and another for data that the
  framework manages.  The former is only editable when a noderole is
  in proposed state, while the latter can be changed by the Crowbar
  framework at any time and should not be editable by the user at
  all.  Wall data still exists as the only inbound data path from a
  Jig run.
- The logic used to decide what roles need to be populated on a
  freshly-discovered node has been made more accurate.
- The admin node now deploys a DNS server as part of its initial
  bootstrap.  The DNS server is not properly configured as of yet.
  
  crowbar.yml |   14 ++++++++++++++
  1 file changed, 14 insertions(+)

Crowbar-Pull-ID: dda46b22e196800cd48f79a273d87621c71cbbfe

Crowbar-Release: development
