### PR TITLE
CB 2.0: Make the network barclamp really work, and make all the recipes really Chef11 compliant. [4/5]

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -113,7 +113,7 @@ def make_zone(zone)
     notifies :reload, "service[bind9]"
     variables(:zones => zonefile_entries)
   end
-  node[:dns][:zone_files] << "/etc/bind/zone.#{zone[:domain]}"
+  node.normal[:dns][:zone_files] << "/etc/bind/zone.#{zone[:domain]}"
 end
 
 # Create our basic zone infrastructure.


### PR DESCRIPTION
This pull request series makes the network barclamp interact with the
core Crowbar framework allow for:
- Dynamic creation of networks at point of need rather than having to
  set them all up ahead of time.
- Presenting networks as roles to the core Crowbar framework.
- Presenting address and network interface allocations as noderoles.

Since this is a first-pass implementation, it lacks a few amenities:
- Networks cannot be edited after they are created.  This will be
  addressed once we get a good idea about what sorts of edits to a
  network make sense in a running cluster, and how to make edits on a
  live cluster with a decent stab at not losing overall connectivity.
- Address allocations can not be deleted once created.  This will be
  enabled once we have a better idea about how to do so in a way that
  does not break the node-role graph.
- The network barclamp only knows how to present information to the
  core, it has no idea how to get information back.
- The admin network is special, and that specialness is hardcoded.  It
  should be driven by configuration metadata from the network-server
  role instead.

This also fixes up a series of non-Chef 11 compliant recipes due to a
combination of bad cache hygene on my part and the Chef 10 client
imnitruck installer having an inexplicably higher priority than the
Chef 11 one.

 chef/cookbooks/bind9/recipes/default.rb |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 402e9ce91111702c1f810a6a19545ee4d489a3f9

Crowbar-Release: development
