### PR TITLE
Split dns-server into 2 different roles. [2/2]

### DIFF
--- a/chef/cookbooks/bind9/recipes/database.rb
+++ b/chef/cookbooks/bind9/recipes/database.rb
@@ -1,0 +1,114 @@
+# Copyright 2011, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# See if anything has changed since last time.  If not, do nothing.
+last_zone = (node[:crowbar_wall][:dns] || Mash.new rescue Mash.new).dup.reject{|k,v|k == "serial"}
+zone = node[:crowbar][:dns].dup
+return if zone == last_zone
+
+admin = node[:crowbar][:dns][:contact].gsub("@",".")
+serial = (node[:crowbar_wall][:dns][:serial] rescue 0) + 1
+zonefiles = [zone[:domain]]
+
+# Arrange for the forward lookup zone to be created.
+template "/etc/bind/db.#{zone[:domain]}" do
+  source "db.erb"
+  mode 0644
+  owner "root"
+  case node[:platform]
+  when "ubuntu","debian" then group "bind"
+  when "centos","redhat","suse" then group "named"
+  end
+  notifies :reload, "service[bind9]"
+  variables(:zone => zone,
+            :serial => serial,
+            :admin => admin,
+            :nameserver => "#{node.name}.")
+end
+
+def populate_soa_defaults(zone)
+  [ :ttl,
+    :serial,
+    :slave_refresh,
+    :slave_retry,
+    :slave_expire,
+    :negative_cache ].each do |k|
+    zone[k] ||= node[:crowbar][:dns][k]
+  end
+  zone
+end
+
+# Arrange for reverse lookup zones to be created.
+# Since there is no elegant method for doing this that takes into account
+# CIDR or IPv6, do it the excessively ugly way and create one zone per IP.
+zone[:hosts].keys.sort.each do |hostname|
+  host=zone[:hosts][hostname]
+  [:ip4addr, :ip6addr].each do |addr|
+    next unless host[addr]
+    rev_zone=Mash.new
+    populate_soa_defaults rev_zone
+    rev_domain=IP.coerce(host[addr]).reverse
+    rev_zone[:domain]=rev_domain
+    rev_zone[:hosts] ||= Mash.new
+    rev_zone[:hosts]["#{rev_domain}."] = Mash.new
+    rev_zone[:hosts]["#{rev_domain}."][:pointer]= if hostname == "@"
+                                                    "#{zone[:domain]}."
+                                                  else
+                                                    "#{hostname}"
+                                                  end
+    Chef::Log.debug "Processing zone: #{rev_zone.inspect}"
+    template "/etc/bind/db.#{rev_domain}" do
+      source "db.erb"
+      mode 0644
+      owner "root"
+      notifies :reload, "service[bind9]"
+      variables(:zone => rev_zone,
+                :serial => serial,
+                :admin => admin,
+                :nameserver => "#{node.name}.")
+    end
+    zonefiles << rev_domain
+  end
+end
+
+node.normal[:crowbar_wall] ||= Mash.new
+node.normal[:crowbar_wall][:dns] = zone
+node.normal[:crowbar_wall][:dns][:serial] = serial
+
+Chef::Log.debug "Creating zone file for zones: #{zonefiles.inspect}"
+template "/etc/bind/zone.#{zone[:domain]}" do
+  source "zone.erb"
+  mode 0644
+  owner "root"
+  case node[:platform]
+  when "ubuntu","debian" then group "bind"
+  when "centos","redhat","suse" then group "named"
+  end
+  notifies :reload, "service[bind9]"
+  variables(:zones => zonefiles)
+end
+
+# Update named.conf.crowbar to include the new zones.
+template "/etc/bind/named.conf.crowbar" do
+  source "named.conf.crowbar.erb"
+  mode 0644
+  owner "root"
+  case node[:platform]
+  when "ubuntu","debian" then group "bind"
+  when "centos","redhat","suse" then group "named"
+  end
+  variables(:zone => zone[:domain])
+  notifies :reload, "service[bind9]"
+end

--- a/chef/cookbooks/bind9/templates/default/db.erb
+++ b/chef/cookbooks/bind9/templates/default/db.erb
@@ -9,9 +9,9 @@ $ORIGIN <%= @zone[:domain] %>.
 $TTL <%= @zone[:ttl] %>
 
 <%= @zone[:domain] -%>. IN SOA (
-    <%= @zone[:nameservers].first %>
-    <%= @zone[:admin] %>
-    <%= @zone[:serial] %>
+    <%= @nameserver %>
+    <%= @admin %>
+    <%= @serial %>
     <%= @zone[:slave_refresh] %>
     <%= @zone[:slave_retry] %>
     <%= @zone[:slave_expire] %>
@@ -19,9 +19,7 @@ $TTL <%= @zone[:ttl] %>
     )
 
 ; Nameservers
-<% @zone[:nameservers].each do |ns| -%>
-@ NS <%= ns %>
-<% end -%>
+@ NS <%= @nameserver %>
 
 ; Mail exchangers
 <% @zone[:mail_exchangers].each do |host,prio| -%>

--- a/chef/cookbooks/bind9/templates/default/named.conf.crowbar.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.crowbar.erb
@@ -1,6 +1,4 @@
 // This file includes all the Crowbar managed zones.
 // Managed by Crowbar.
 // Do not edit.
-<% @zonefiles.each do |zonefile| -%>
-include "<%= zonefile -%>";
-<% end -%>
+include "zone.<%= @zone -%>";

--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -18,22 +18,13 @@
 # limitations under the License.
 #
 
-env_filter = " AND dns_config_environment:#{node[:dns][:config][:environment]}"
-nodes = search(:node, "roles:dns-server#{env_filter}")
-
-dns_list = []
-if nodes and !nodes.empty?
-  dns_list = nodes.map { |x| x.address.addr }
-elsif node["crowbar"] and node["crowbar"]["admin_node"] and node[:dns][:forwarders]
-  dns_list << node[:dns][:forwarders]
-end
-
-dns_list << node[:dns][:nameservers]
+dns_list = (node[:crowbar][:dns][:nameservers] rescue nil) ||
+  (node[:crowbar][:dns][:server][:forwarders] rescue [])
 
 template "/etc/resolv.conf" do
   source "resolv.conf.erb"
   owner "root"
   group "root"
   mode 0644
-  variables(:nameservers => dns_list.flatten, :search => (node[:dns][:domain] rescue nil))
+  variables(:nameservers => dns_list.flatten, :search => (node[:crowbar][:dns][:domain] rescue nil))
 end

--- a/chef/roles/dns-database.rb
+++ b/chef/roles/dns-database.rb
@@ -1,0 +1,5 @@
+name "dns-database"
+description "DNS Database Role - DNS server for the cloud"
+run_list(
+         "recipe[bind9::database]"
+)

--- a/chef/roles/dns-server.rb
+++ b/chef/roles/dns-server.rb
@@ -4,18 +4,4 @@ description "DNS Server Role - DNS server for the cloud"
 run_list(
          "recipe[bind9]"
 )
-default_attributes "dns" => {
-  "static" => {},
-  "forwarders" => [],
-  "domain" => "",
-  "contact" => "support@localhost.localdomain",
-  "ttl" => "1h",
-  "serial" => 1,
-  "slave_refresh" => "1d",
-  "slave_retry" => "2h",
-  "slave_expire" => "4w",
-  "negative_cache" => 300,
-  "config" => { "environment" => "dns-base-config" }
-}
-override_attributes()
 

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -34,6 +34,12 @@ roles:
       - bootstrap
     requires:
       - network-admin
+  - name: dns-database
+    jig: chef
+    flags:
+      - bootstrap
+    requires:
+      - dns-server
   - name: dns-client
     jig: chef
     flags:

--- a/crowbar_engine/barclamp_dns/app/models/barclamp_dns/client.rb
+++ b/crowbar_engine/barclamp_dns/app/models/barclamp_dns/client.rb
@@ -1,0 +1,18 @@
+# Copyright 2013, Dell 
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+# 
+
+class BarclampDns::Client < Role
+  
+end

--- a/crowbar_engine/barclamp_dns/app/models/barclamp_dns/database.rb
+++ b/crowbar_engine/barclamp_dns/app/models/barclamp_dns/database.rb
@@ -1,0 +1,60 @@
+# Copyright 2013, Dell 
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+# 
+
+class BarclampDns::Database < Role
+
+
+  def on_node_create(n)
+    rerun_my_noderoles
+  end
+
+  def on_node_delete(n)
+    rerun_my_noderoles
+  end
+
+  def sysdata(nr)
+    hosts = {}
+    # Record our host entry information first.
+    Node.all.each do |n|
+      v4addrs,v6addrs = n.addresses.partition{|a|a.v4?}
+      canonical_name = n.name + "."
+      hosts[canonical_name] = Hash.new
+      hosts[canonical_name]["ip6addr"] = v6addrs.sort.first.addr unless v6addrs.empty?
+      hosts[canonical_name]["ip4addr"] = v4addrs.sort.first.addr unless v4addrs.empty?
+      if n.alias && !canonical_name.index(n.alias)
+        hosts[canonical_name]["alias"] = n.alias
+      end
+    end
+    # Populate the rest of the zone information
+    { "crowbar" => {
+        "dns" => {
+          "hosts" => hosts
+        }
+      }
+    }
+  end
+
+  private
+
+  def rerun_my_noderoles
+    r = Role.where(:name => "dns-database").first
+    return if r.nil?
+    r.node_roles.committed.in_state(NodeRole::ACTIVE).each do |nr|
+      nr.run!
+    end
+  end
+
+end
+

--- a/crowbar_engine/barclamp_dns/app/models/barclamp_dns/server.rb
+++ b/crowbar_engine/barclamp_dns/app/models/barclamp_dns/server.rb
@@ -1,0 +1,41 @@
+# Copyright 2013, Dell 
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+# 
+
+require 'json'
+class BarclampDns::Server < Role
+
+  def template
+    JSON.generate({"crowbar" => {
+                      "dns" => {
+                        "domain" => Node.admin.first.name.split(".",2)[1],
+                        "contact" => "support@localhost.localdomain",
+                        "forwarders" =>  [],
+                        "static" => {},
+                        "ttl" => "1h",
+                        "slave_refresh" => "1d",
+                        "slave_retry" => "2h",
+                        "slave_expire" => "4w",
+                        "negative_cache" => 300}}})
+  end
+
+  def sysdata(nr)
+    {"crowbar" => {
+        "dns" => {
+          "nameservers" => nr.node.addresses.flatten.sort.map{|a|a.addr}
+        }
+      }
+    }
+  end
+end


### PR DESCRIPTION
This pull request set splits dns-server into 2 smaller roles:
- dns-server, which does the initial setup of bind, and
- dns-database, which is reasposible for ongoing maintenance of the
  bind9 zone for the admin network of the cluster.

This also adds some infrastructure in the Crowbar barclamp to
facilitate poking the dns-database role whenever a node is created or
destroyed.

 chef/cookbooks/bind9/recipes/database.rb           | 114 +++++++++++++++
 chef/cookbooks/bind9/recipes/default.rb            | 161 +--------------------
 chef/cookbooks/bind9/templates/default/db.erb      |  10 +-
 .../bind9/templates/default/named.conf.crowbar.erb |   4 +-
 chef/cookbooks/resolver/recipes/default.rb         |  15 +-
 chef/roles/dns-database.rb                         |   5 +
 chef/roles/dns-server.rb                           |  14 --
 crowbar.yml                                        |   6 +
 .../barclamp_dns/app/models/barclamp_dns/client.rb |  18 +++
 .../app/models/barclamp_dns/database.rb            |  60 ++++++++
 .../barclamp_dns/app/models/barclamp_dns/server.rb |  41 ++++++
 11 files changed, 259 insertions(+), 189 deletions(-)

Crowbar-Pull-ID: 763d805705b2c4a304d3ae9606be913bd4cca504

Crowbar-Release: development
