### PR TITLE
Fully bootstrap nodes into Sledgehammer [6/7]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -32,6 +32,7 @@ roles:
     jig: chef
     flags:
       - bootstrap
+      - server
     requires:
       - network-admin
   - name: dns-database


### PR DESCRIPTION
This pull request series fixes a bunch of bugs that were keeping the
Crowbar admin node from bootstrapping all of the discovery roles in
Sledgehammer.
- Fixed several race conditions caused by noderoles being marked as
  ACTIVE before all their wall data had been written and saved.  Jigs
  wait until the very last instant before marking a noderole as
  ACTIVE.
- Stop trying to install packages in bootstrap roles if the executable
  we need is already present on the system.
- Tune the role binding logic to make better choices when picking
  parent noderoles. Role.add_to_node_in_snapshot should make better
  binding choices -- in particular, it will always handle the implicit
  flag properly, and it will respect the overall ordering of noderoles
  imposed by the deployment tree instad of jsut looking on the current
  node and then on all the nodes.
- Shift to not sharing attribute information amongst noderoles by
  default.  The annealer used to just smash all of the attributes in
  all of the parent noderoles together to determine what would be fed
  to the jig when adding a new noderole to a jig -- this led to
  unintended intermittent information leakage between nodes.  Now,
  roles that should share information with their children must have a
  server flag in the appropriate crowbar.yml.  The annealer now only
  considers attributes from active or transitioning noderoles on the
  same system + active noderoles that are parents of the noderoles on
  the system. This is intended as a stopgap measure until we get
  around to formalizing attributes on a per-role basis.
  
  crowbar.yml | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: adf59d76e7c4525496432dae4e35f36b067b56c2

Crowbar-Release: development
