### PR TITLE
use forward only option

### DIFF
--- a/chef/cookbooks/bind9/templates/default/named.conf.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.erb
@@ -20,6 +20,7 @@ options {
 <%   end -%>
 	};
 <% end -%>
+	forward only;
 
 <% if !@allow_transfer.nil? and !@allow_transfer.empty? -%>
         allow-transfer {


### PR DESCRIPTION
- this is needed to resolve reverse DNS for external private IPs
  because bind 9.9 defaults to empty-zones-enable yes
- this allows to better run behind firewalls
