### PR TITLE
Set forward-only only on SUSE

### DIFF
--- a/chef/cookbooks/bind9/templates/default/named.conf.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.erb
@@ -19,8 +19,8 @@ options {
          <%= i %>;
 <%   end -%>
 	};
-<% end -%>
 	forward only;
+<% end -%>
 
 <% if !@allow_transfer.nil? and !@allow_transfer.empty? -%>
         allow-transfer {


### PR DESCRIPTION
Should fix https://github.com/crowbar/barclamp-dns/commit/51c43a39eda5fca034c53e591f22b71bcb324db9
