### PR TITLE
BDD Test Coverage Improvement (just 1 left!) [3/3]

### DIFF
--- a/crowbar_engine/barclamp_dns/app/models/barclamp_dns/database.rb
+++ b/crowbar_engine/barclamp_dns/app/models/barclamp_dns/database.rb
@@ -58,7 +58,7 @@ class BarclampDns::Database < Role
         next unless nr.active? || nr.transition?
         # We need to re-enqueue for both active and transition here,
         # as the previous run might not have finished yet.
-        Rails.logger.info("dns-database: Enqueuing run for #{nr.name}") unless nr.nil?
+        Rails.logger.info("dns-database: Enqueuing run for #{nr.name}") 
         Run.enqueue(nr)
       end
     end


### PR DESCRIPTION
This change recoveres the BDD coverage lost when we improved the annealer.

The primary change is to have the test jig "take over" roles of other jigs 
if that jigs is not active but the test jig is active.

This minor change enabled the system to run as if there was a real jig.

The only other "major" change was to turn off node.alive=false if you are testing
since the system lacks the external node to trigger alive=true.

This in turn uncovered some minor places where log messages could catch nils
that had to be protected.

I did some other very minor cleanups.

 .../app/models/barclamp_dns/database.rb            |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 49bb3a6e7c547e86059972236176f307d83b19a8

Crowbar-Release: development
