### PR TITLE
Allow users to set MAC address in DHCP database when node is created AND deal w/ issues created when we changed the attribute system [4/5]

### DIFF
--- a/crowbar_engine/barclamp_dns/app/models/barclamp_dns/server.rb
+++ b/crowbar_engine/barclamp_dns/app/models/barclamp_dns/server.rb
@@ -19,8 +19,7 @@ class BarclampDns::Server < Role
   def template
     # this is a workable solution for now, we use the admin node to determine domain (except when non-exists!)
     domain = Node.admin.first.name.split(".",2)[1] rescue I18n.t('not_set')
-    JSON.generate({"crowbar" => {
-                      "dns" => {
+    {"crowbar" => {     "dns" => {
                         "domain" => domain,
                         "contact" => "support@localhost.localdomain",
                         "forwarders" =>  [],
@@ -29,7 +28,7 @@ class BarclampDns::Server < Role
                         "slave_refresh" => "1d",
                         "slave_retry" => "2h",
                         "slave_expire" => "4w",
-                        "negative_cache" => 300}}})
+                        "negative_cache" => 300}}}
   end
 
   def sysdata(nr)


### PR DESCRIPTION
This pull request started as a very simple, add another HINT into nodes for DHCP database.
This was added to the provisioner database and includes TESTs.

Creating those tests exposed a lot of work needed to make sure that BDD was testing
the full annealer including that background workers were running and the annealer
queue was flushed before we checked for changed states.

During that time, @VictorLowther changed the way that we deal with attributes.  I 
updated the code in the node.hint to also use the attribute system as designed. 
This was a good improvement and more general.

The attribute system changes exposed inconsistencies in how we were dealing with 
role.template and other places were we store data.  I had to fix all those so 
that the tests were passing.

TESTS ROCK.

 .../barclamp_dns/app/models/barclamp_dns/server.rb |    5 ++---
 1 file changed, 2 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: 66d40a815aa402d4c2c9bee71df46a05ed8e8f57

Crowbar-Release: development
