### PR TITLE
CB 2: Make all the things use wants-attrib for smart attribute injection. [6/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -30,19 +30,25 @@ barclamp:
 roles:
   - name: dns-server
     jig: chef-solo
-    flags:
-      - server
     requires:
       - network-admin
     attribs:
+      - name: dns_all_data
+        description: 'All the DNS server information'
+        map: 'crowbar/dns'
       - name: dns_servers
         description: 'DNS servers that all Crowbar clients should use'
         map: 'crowbar/dns/nameservers'
+      - name: dns_domain
+        description: "The DNS domain name that Crowbar is using."
+        map: 'crowbar/dns/domain'
   - name: dns-database
     jig: chef-solo
     flags:
     requires:
       - dns-server
+    wants-attribs:
+      - dns_all_data
   - name: dns-client
     jig: chef-solo
     flags:
@@ -51,8 +57,7 @@ roles:
       - dns-server
       - network-admin
     wants-attribs:
-      - name: dns_servers
-        at: 'crowbar/dns/nameservers'
+      - dns_servers
 
 crowbar:
   layout: 2.0


### PR DESCRIPTION
This pull request series switches the core Crowbar framework to be
smarter about injecting just the attributes that a role declares that
it needs, instead of just smashing everything that could be in scope
together.

 crowbar.yml | 13 +++++++++----
 1 file changed, 9 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: dccf04341e8a02b81a47fd321efe6c0256033410

Crowbar-Release: development
