### PR TITLE
[roxy] Allow to deploy more than one DNS server

### DIFF
--- a/chef/cookbooks/bind9/attributes/default.rb
+++ b/chef/cookbooks/bind9/attributes/default.rb
@@ -1,3 +1,3 @@
-
+default[:dns][:master] = true
 default[:dns][:forwarders] = [ ]
 default[:dns][:allow_transfer] = [ ]

--- a/chef/cookbooks/bind9/templates/default/named.conf.default-zones.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.default-zones.erb
@@ -3,12 +3,22 @@
 // broadcast zones as per RFC 1912
 
 zone "0.in-addr.arpa" {
+<% if node[:dns][:master] -%>
         type master;
+<% else -%>
+        type slave;
+        masters { <%= @master_ip -%>; };
+<% end %>
         file "/etc/bind/db.0";
 };
 
 zone "255.in-addr.arpa" {
+<% if node[:dns][:master] -%>
         type master;
+<% else -%>
+        type slave;
+        masters { <%= @master_ip -%>; };
+<% end %>
         file "/etc/bind/db.255";
 };
 

--- a/chef/cookbooks/bind9/templates/default/named.conf.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.erb
@@ -28,6 +28,7 @@ options {
           <%= at %>;
 <%   end -%>
         };
+        notify yes;
 <% end -%>
 
 	auth-nxdomain no;    # conform to RFC1035

--- a/chef/cookbooks/bind9/templates/default/zone.erb
+++ b/chef/cookbooks/bind9/templates/default/zone.erb
@@ -2,5 +2,9 @@
 // Do not edit.
 
 <% @zones.each do |zone| -%>
+<%   if node[:dns][:master] -%>
 zone "<%= zone -%>" { type master; file "/etc/bind/db.<%= zone -%>"; };
+<%   else -%>
+zone "<%= zone -%>" { type slave; masters { <%= @master_ip -%>; }; file "/etc/bind/db.<%= zone -%>"; };
+<%   end %>
 <% end %>

--- a/chef/cookbooks/resolver/templates/default/resolv.conf.erb
+++ b/chef/cookbooks/resolver/templates/default/resolv.conf.erb
@@ -1,3 +1,4 @@
+options rotate
 <% unless @search.nil? -%>
 search <%= @search %>
 <% end -%>

--- a/crowbar_framework/app/helpers/dns_barclamp_helper.rb
+++ b/crowbar_framework/app/helpers/dns_barclamp_helper.rb
@@ -22,7 +22,7 @@ module DnsBarclampHelper
     {
       "dns-server" => {
         "unique" => false,
-        "count" => 1,
+        "count" => 3,
         "admin" => true
       },
       "dns-client" => {

--- a/crowbar_framework/app/models/dns_service.rb
+++ b/crowbar_framework/app/models/dns_service.rb
@@ -28,7 +28,7 @@ class DnsService < ServiceObject
   end
 
   def validate_proposal_after_save proposal
-    validate_one_for_role proposal, "dns-server"
+    validate_at_least_n_for_role proposal, "dns-server", 1
 
     super
   end
@@ -64,5 +64,56 @@ class DnsService < ServiceObject
     [200, NodeObject.find_node_by_name(name).to_hash ]
   end
 
+  def apply_role_pre_chef_call(old_role, role, all_nodes)
+    @logger.debug("DNS apply_role_pre_chef_call: entering #{all_nodes.inspect}")
+    return if all_nodes.empty?
+
+    slave_ips = []
+    nodes = NodeObject.all
+    admin = nodes.select { |n| n.admin? }
+    tnodes = role.override_attributes["dns"]["elements"]["dns-server"]
+
+    slave_nodes = tnodes
+
+    # electing master dns-server
+    master = nil
+    tnodes.each do |n|
+      node = NodeObject.find_node_by_name n
+      if node[:dns][:master]
+        master = node
+        break
+      end
+    end
+    if master.nil?
+      if tnodes.include?(admin[0].name)
+        master = admin[0]
+      else
+        master = NodeObject.find_node_by_name tnodes.shift
+      end
+    end
+
+    slave_nodes.delete(master.name)
+    slave_nodes.each do |n|
+      node = NodeObject.find_node_by_name n
+      slave_ips << node[:crowbar][:network][:admin][:address]
+    end
+
+    master[:dns][:master] = true
+    master[:dns][:master_ip] = master[:crowbar][:network][:admin][:address]
+    master[:dns][:slave_ips] = slave_ips
+    master[:dns][:slave_names] = slave_nodes
+    master.save
+
+    slave_nodes.each do |n|
+      node = NodeObject.find_node_by_name n
+      node[:dns][:master_ip] = master[:crowbar][:network][:admin][:address]
+      node[:dns][:slave_ips] = slave_ips
+      node[:dns][:slave_names] = slave_nodes
+      node[:dns][:master] = false
+      node.save
+    end
+
+    @logger.debug("DNS apply_role_pre_chef_call: leaving")
+  end
 
 end


### PR DESCRIPTION
Each infrastructure should have at least two DNS servers primary and secondary.
This patch adding possibility to deploy 3 dns servers one primary and two secondaries.
Primary DNS server will be elected during applying roles.
DNS zones will be synchronized from primary DNS server to secondaries using notifications.
