### PR TITLE
Fix return of node hash

### DIFF
--- a/crowbar_framework/app/models/dns_service.rb
+++ b/crowbar_framework/app/models/dns_service.rb
@@ -54,7 +54,7 @@ class DnsService < ServiceObject
       @logger.debug("DNS transition: adding #{name} to dns-client role")
       result = add_role_to_instance_and_node("dns", inst, name, db, role, "dns-client")
 
-      a= [200, NodeObject.find_node_by_name(name).to_hash ] if result
+      a = [200, { :name => name } ] if result
       a = [400, "Failed to add role to node"] unless result
       @logger.debug("DNS transition: leaving for #{name} for #{state}: discovered")
       return a


### PR DESCRIPTION
Return a hash with name instead.

This was missed in PR #84.
