### PR TITLE
Fix hostnames for admin virtual IPs

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -201,7 +201,7 @@ search(:crowbar, "id:*_network").each do |network|
       next
     end
     base_name=host.chomp(".#{node[:dns][:domain]}")
-    unless network.name == "admin"
+    unless net_name == "admin"
       base_name="#{net_name}.#{base_name}"
     end
     cluster_zone[:hosts][base_name] ||= Mash.new


### PR DESCRIPTION
Because of a wrong check, we are always creating "admin.$foo" hostnames
for virtual IPs in the admin network, while this should really be just
"$foo".
