### PR TITLE
Add dependencies in bind9 metadata

### DIFF
--- a/chef/cookbooks/bind9/metadata.json
+++ b/chef/cookbooks/bind9/metadata.json
@@ -35,6 +35,8 @@
   "replacing": {
   },
   "dependencies": {
+    "resolver": ">= 0.0.0",
+    "utils": ">= 0.0.0"
   },
   "groupings": {
   },


### PR DESCRIPTION
We include recipes from other cookbooks.

https://bugzilla.novell.com/show_bug.cgi?id=869688
