### PR TITLE
Don't try install dnsmasq for sledgehammer image

### DIFF
--- a/chef/cookbooks/resolver/templates/default/resolv.conf.erb
+++ b/chef/cookbooks/resolver/templates/default/resolv.conf.erb
@@ -1,7 +1,6 @@
 <% unless @search.nil? -%>
 search <%= @search %>
 <% end -%>
-nameserver 127.0.0.1
 <% @nameservers.each do |nameserver| -%>
 nameserver <%= nameserver %>
 <% end -%>


### PR DESCRIPTION
Sledgehammer for SLES was updated and it is build with dnsmasq package. We don't want install it once again when node is booted with sledgehammer image.
