### PR TITLE
Disable allow-transfer when no IP is specified for it

### DIFF
--- a/chef/cookbooks/bind9/templates/default/named.conf.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.erb
@@ -33,6 +33,10 @@ options {
             <%= at %>;
 <% end -%>
         };
+<% else -%>
+        allow-transfer {
+            "none";
+        };
 <% end -%>
         auth-nxdomain no;    # conform to RFC1035
         listen-on { <%= @ipaddress %>; };


### PR DESCRIPTION
I think that's what should be the meaning of "no IP specified".