### PR TITLE
Do not install dnsmasq on node with dns-server role, (bnc#912039)

### DIFF
--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -32,7 +32,7 @@ dns_list << node[:dns][:nameservers]
 
 unless node[:platform] == "windows"
   states = [ "ready", "readying", "recovering", "applying" ]
-  if states.include?(node[:state])
+  if states.include?(node[:state]) && !node.roles.include?("dns-server")
     package "dnsmasq"
 
     template "/etc/dnsmasq.conf" do


### PR DESCRIPTION
This patch resolve conflict between bind9 and dnsmasq services during
upgrade from SUSE Cloud 4 to SUSE Cloud 5. It was reported in Bug 912039

https://bugzilla.suse.com/show_bug.cgi?id=912039