### PR TITLE
Change run_list order and execute dns-server role before dns-client

### DIFF
--- a/chef/data_bags/crowbar/bc-template-dns.json
+++ b/chef/data_bags/crowbar/bc-template-dns.json
@@ -14,7 +14,7 @@
     "dns": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 2,
+      "schema-revision": 3,
       "element_states": {
         "dns-server": [ "readying", "ready", "applying" ],
         "dns-client": [ "all" ]
@@ -24,6 +24,10 @@
         [ "dns-server" ],
         [ "dns-client" ]
       ],
+      "element_run_list_order": {
+        "dns-server": 30,
+        "dns-client": 31
+      },
       "config": {
         "environment": "dns-base-config",
         "mode": "full",

--- a/chef/data_bags/crowbar/bc-template-dns.schema
+++ b/chef/data_bags/crowbar/bc-template-dns.schema
@@ -93,6 +93,16 @@
                 "sequence": [ { "type": "str" } ]
               } ]
             },
+            "element_run_list_order": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                = : {
+                  "type": "int",
+                  "required": true
+                }
+              }
+            },
             "config": {
               "type": "map",
               "required": true,

--- a/chef/data_bags/crowbar/migrate/dns/003_add_element_run_list_order.rb
+++ b/chef/data_bags/crowbar/migrate/dns/003_add_element_run_list_order.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  d['element_run_list_order'] = td['element_run_list_order']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('element_run_list_order')
+  return a, d
+end


### PR DESCRIPTION
We would like to reconfigure named service first and bind it to admin interface, before dnsmasq will be installed and will start listen on the local interface. 

This is needed for upgrade process.

Change for installation dnsmasq on dns-servers https://github.com/crowbar/barclamp-dns/pull/122