### PR TITLE
Fix migration to change the run list order for all dns-client nodes

### DIFF
--- a/chef/data_bags/crowbar/migrate/dns/003_add_element_run_list_order.rb
+++ b/chef/data_bags/crowbar/migrate/dns/003_add_element_run_list_order.rb
@@ -1,8 +1,9 @@
 def upgrade ta, td, a, d
   d['element_run_list_order'] = td['element_run_list_order']
 
-  # Make sure that all dns-servers will refresh roles order for run_list
-  nodes = NodeObject.find('roles:dns-server')
+  # Make sure that all nodes have the proper run list order for the dns-client
+  # role
+  nodes = NodeObject.find('roles:dns-client')
   nodes.each do |node|
     node.delete_from_run_list('dns-client')
     node.add_to_run_list('dns-client',


### PR DESCRIPTION
It's important to change that for all dns-client nodes, not just for
dns-server nodes as a dns-client node might get the dns-server role
later on, and we want to have the right order in that case.