### PR TITLE
Allow disabling the DNS-Server

### DIFF
--- a/chef/data_bags/crowbar/bc-template-dns.json
+++ b/chef/data_bags/crowbar/bc-template-dns.json
@@ -7,14 +7,15 @@
       "forwarders": [ ],
       "allow_transfer": [ ],
       "nameservers": [ ],
-      "records": { }
+      "records": { },
+      "auto_assign_server": true
     }
   },
   "deployment": {
     "dns": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 3,
+      "schema-revision": 4,
       "element_states": {
         "dns-server": [ "readying", "ready", "applying" ],
         "dns-client": [ "all" ]

--- a/chef/data_bags/crowbar/bc-template-dns.schema
+++ b/chef/data_bags/crowbar/bc-template-dns.schema
@@ -44,6 +44,10 @@
                   }
                 }
               }
+            },
+            "auto_assign_server": {
+              "type": "bool",
+              "required": true
             }
           }
         }

--- a/chef/data_bags/crowbar/migrate/dns/004_add_auto_assign_server.rb
+++ b/chef/data_bags/crowbar/migrate/dns/004_add_auto_assign_server.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  a['auto_assign_server'] = ta['auto_assign_server']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('auto_assign_server')
+  return a, d
+end

--- a/crowbar_framework/app/models/dns_service.rb
+++ b/crowbar_framework/app/models/dns_service.rb
@@ -71,10 +71,12 @@ class DnsService < ServiceObject
       db = ProposalObject.find_proposal "dns", inst
       role = RoleObject.find_role_by_name "dns-config-#{inst}"
 
-      if role.override_attributes["dns"]["elements"]["dns-server"].nil? or
-         role.override_attributes["dns"]["elements"]["dns-server"].empty?
-        @logger.debug("DNS transition: adding #{name} to dns-server role")
-        result = add_role_to_instance_and_node("dns", inst, name, db, role, "dns-server")
+      if role.override_attributes["dns"]["auto_assign_server"]
+        if role.override_attributes["dns"]["elements"]["dns-server"].nil? or
+           role.override_attributes["dns"]["elements"]["dns-server"].empty?
+          @logger.debug("DNS transition: adding #{name} to dns-server role")
+          result = add_role_to_instance_and_node("dns", inst, name, db, role, "dns-server")
+        end
       end
 
       # Always add the dns client

--- a/crowbar_framework/app/models/dns_service.rb
+++ b/crowbar_framework/app/models/dns_service.rb
@@ -50,7 +50,12 @@ class DnsService < ServiceObject
   end
 
   def validate_proposal_after_save proposal
-    validate_at_least_n_for_role proposal, "dns-server", 1
+    server_role = proposal["deployment"]["dns"]["elements"]["dns-server"]
+    nameservers = proposal["attributes"]["dns"]["nameservers"]
+
+    if server_role.blank? && nameservers.blank?
+      validation_error("At least one nameserver or one node with the dns-server role must be specified.")
+    end
 
     super
   end
@@ -91,38 +96,40 @@ class DnsService < ServiceObject
     return if all_nodes.empty?
 
     tnodes = role.override_attributes["dns"]["elements"]["dns-server"]
-    nodes = tnodes.map {|n| NodeObject.find_node_by_name n}
 
-    # electing master dns-server
-    master = nil
-    admin = nil
-    nodes.each do |node|
-      if node[:dns][:master]
-        master = node
-        break
-      elsif node.admin?
-        admin = node
+    if !tnodes.blank?
+      nodes = tnodes.map {|n| NodeObject.find_node_by_name n}
+      # electing master dns-server
+      master = nil
+      admin = nil
+      nodes.each do |node|
+        if node[:dns][:master]
+          master = node
+          break
+        elsif node.admin?
+          admin = node
+        end
       end
-    end
-    if master.nil?
-      unless admin.nil?
-        master = admin
-      else
-        master = nodes.first
+      if master.nil?
+        unless admin.nil?
+          master = admin
+        else
+          master = nodes.first
+        end
       end
-    end
 
-    slave_ips = nodes.map {|n| n[:crowbar][:network][:admin][:address]}
-    slave_ips.delete(master[:crowbar][:network][:admin][:address])
-    slave_nodes = tnodes.dup
-    slave_nodes.delete(master.name)
+      slave_ips = nodes.map {|n| n[:crowbar][:network][:admin][:address]}
+      slave_ips.delete(master[:crowbar][:network][:admin][:address])
+      slave_nodes = tnodes.dup
+      slave_nodes.delete(master.name)
 
-    nodes.each do |node|
-      node.set[:dns][:master_ip] = master[:crowbar][:network][:admin][:address]
-      node.set[:dns][:slave_ips] = slave_ips
-      node.set[:dns][:slave_names] = slave_nodes
-      node.set[:dns][:master] = (master.name == node.name)
-      node.save
+      nodes.each do |node|
+        node.set[:dns][:master_ip] = master[:crowbar][:network][:admin][:address]
+        node.set[:dns][:slave_ips] = slave_ips
+        node.set[:dns][:slave_names] = slave_nodes
+        node.set[:dns][:master] = (master.name == node.name)
+        node.save
+      end
     end
 
     @logger.debug("DNS apply_role_pre_chef_call: leaving")

--- a/crowbar_framework/app/views/barclamp/dns/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/dns/_edit_attributes.html.haml
@@ -21,6 +21,9 @@
       %legend
         = t(".client_configuration")
 
+      .alert.alert-warning
+        = t(".server_hint")
+
       = array_string_field :nameservers
       %span.help-block
         = t('.ip_list_hint')

--- a/crowbar_framework/config/locales/dns/en.yml
+++ b/crowbar_framework/config/locales/dns/en.yml
@@ -21,6 +21,7 @@ en:
       edit_attributes:
         domain: 'Domain'
         ip_list_hint: 'A comma-separated list of IP Addresses'
+        server_hint: 'At least one nameserver or one node with the dns-server role must be specified.'
 
         server_configuration: 'Server Configuration'
         forwarders: 'Forwarders'


### PR DESCRIPTION
The disable_server option deactivates the local DNS-Server and uses the
provided DNS-Servers to handle all requests.