### PR TITLE
Fix auto_assign_server handling

### DIFF
--- a/crowbar_framework/app/models/dns_service.rb
+++ b/crowbar_framework/app/models/dns_service.rb
@@ -71,7 +71,7 @@ class DnsService < ServiceObject
       db = ProposalObject.find_proposal "dns", inst
       role = RoleObject.find_role_by_name "dns-config-#{inst}"
 
-      if role.override_attributes["dns"]["auto_assign_server"]
+      if db["attributes"]["dns"]["auto_assign_server"]
         if role.override_attributes["dns"]["elements"]["dns-server"].nil? or
            role.override_attributes["dns"]["elements"]["dns-server"].empty?
           @logger.debug("DNS transition: adding #{name} to dns-server role")


### PR DESCRIPTION
The RoleObject has at this time not the auto_assign_server attribute so
we load the data from the ProposalObject.