### PR TITLE
Make dnsmasq not rely on external /etc/resolv-forwarders.conf file

### DIFF
--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -41,21 +41,18 @@ unless node[:platform] == "windows"
       owner "root"
       group "root"
       mode 0644
+      # do a dup, because we'll insert 127.0.0.1 later on
+      variables(:nameservers => dns_list.dup)
     end
 
-    template "/etc/resolv-forwarders.conf" do
-      source "resolv-forwarders.conf.erb"
-      owner "root"
-      group "root"
-      mode 0644
-      variables(:nameservers => dns_list)
+    file "/etc/resolv-forwarders.conf" do
+      action :delete
     end
 
     service "dnsmasq" do
       supports :status => true, :start => true, :stop => true, :restart => true
       action [:enable, :start]
       subscribes :restart, "template[/etc/dnsmasq.conf]"
-      subscribes :restart, "template[/etc/resolv-forwarders.conf]"
     end
 
     dns_list = dns_list.insert(0, "127.0.0.1").take(3)

--- a/chef/cookbooks/resolver/templates/default/dnsmasq.conf.erb
+++ b/chef/cookbooks/resolver/templates/default/dnsmasq.conf.erb
@@ -43,7 +43,7 @@ port=53
 
 # Change this line if you want dns to get its upstream servers from
 # somewhere other that /etc/resolv.conf
-resolv-file=/etc/resolv-forwarders.conf
+#resolv-file=
 
 # By  default,  dnsmasq  will  send queries to any of the upstream
 # servers it knows about and tries to favour servers to are  known
@@ -55,7 +55,7 @@ resolv-file=/etc/resolv-forwarders.conf
 # If you don't want dnsmasq to read /etc/resolv.conf or any other
 # file, getting its servers from this file instead (see below), then
 # uncomment this.
-#no-resolv
+no-resolv
 
 # If you don't want dnsmasq to poll /etc/resolv.conf or other resolv
 # files for changes and re-read them then uncomment this.
@@ -64,6 +64,9 @@ resolv-file=/etc/resolv-forwarders.conf
 # Add other name servers here, with domain specs if they are for
 # non-public domains.
 #server=/localnet/192.168.0.1
+<% @nameservers.each do |nameserver| -%>
+server=<%= nameserver %>
+<% end -%>
 
 # Example of routing PTR queries to nameservers: this will send all
 # address->name queries for 192.168.3/24 to nameserver 10.1.2.3

--- a/chef/cookbooks/resolver/templates/default/resolv-forwarders.conf.erb
+++ b/chef/cookbooks/resolver/templates/default/resolv-forwarders.conf.erb
@@ -1,3 +1,0 @@
-<% @nameservers.each do |nameserver| -%>
-nameserver <%= nameserver %>
-<% end -%>


### PR DESCRIPTION
The settings can very well be in dnsmasq.conf (for which we have a
template), and when apparmor is used, dnsmasq can't read that file.

That also means that we need to use the no-resolv option to not have
dnsmasq use /etc/resolv.conf (since we don't override that file
anymore).